### PR TITLE
Fix lesson regression

### DIFF
--- a/hahapapa/hahapapa/xxiivvViewController.m
+++ b/hahapapa/hahapapa/xxiivvViewController.m
@@ -183,7 +183,9 @@ AVAudioPlayer *audioPlayerSounds;
 	[self templateChoiceIncorrectAnimation];
 	
 	userLesson -= 6;
-	userLesson = abs(userLesson);
+    if (userLesson < 0) {
+        userLesson = 0;
+    }
 }
 
 


### PR DESCRIPTION
I noticed that by getting a choice incorrect sometimes the user would actually advance in their lessons.

This change causes incorrect answers to move the user back to the first one in the specified increments (6), where they will stay until they start getting the answers correct again.
